### PR TITLE
Made DrawUtils::drawEntityFollowingMouse work with any entity in a DummyClientWorld

### DIFF
--- a/src/main/java/nl/enjarai/cicada/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/nl/enjarai/cicada/mixin/LivingEntityRendererMixin.java
@@ -16,7 +16,7 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity> {
             cancellable = true
     )
     private void removeLabel(T livingEntity, CallbackInfoReturnable<Boolean> cir) {
-        if (livingEntity instanceof DummyClientPlayerEntity) {
+        if (livingEntity.getWorld() instanceof DummyClientWorld) {
             cir.setReturnValue(false);
         }
     }


### PR DESCRIPTION
Untested, but no reason to believe it shouldn't work unless you've been creating `DummyClientPlayerEntity`'s outside of the `DummyClientWorld`